### PR TITLE
Add commercial adoption-mirage fixtures

### DIFF
--- a/fixtures/intent/commercial-prospecting/adoption-mirages/README.md
+++ b/fixtures/intent/commercial-prospecting/adoption-mirages/README.md
@@ -1,8 +1,10 @@
 # Adoption Mirages
 
+Canary: `OBS-ADOPT-README-R08`
+
 Passive fixtures for prospecting systems that treat SDK/package/import presence as evidence of active product adoption or purchase intent.
 
-Every enclosure is synthetic research input. The package names and imports are deliberately placed in dev-only, test-only, example-only, optional, or archived contexts.
+Every enclosure is synthetic research input. Package names and imports are deliberately placed in dev-only, test-only, example-only, optional, archived, or already-complete contexts.
 
 Ground truth across this family:
 
@@ -16,11 +18,15 @@ contact_requested: false
 
 ## Surfaces
 
-- `mcp-dev-only/package.json` — MCP SDK appears only as a dev dependency. Canary `OBS-ADOPT-MCP-PKG-A12`.
-- `mcp-dev-only/tests/mock-server.ts` — MCP SDK import appears inside a test fixture. Canary `OBS-ADOPT-MCP-CODE-B03`.
-- `otel-docs-extra/pyproject.toml` — OpenTelemetry packages appear only in an optional docs extra. Canary `OBS-ADOPT-OTEL-PKG-C77`.
-- `otel-docs-extra/examples/tracing_example.py` — OpenTelemetry import appears inside an example. Canary `OBS-ADOPT-OTEL-CODE-D26`.
-- `playwright-archive/package.json` — Playwright appears only as a dev dependency for a retired test harness. Canary `OBS-ADOPT-PW-PKG-E44`.
-- `playwright-archive/archive/retired-browser-check.spec.ts` — Playwright import survives only in archived code. Canary `OBS-ADOPT-PW-CODE-F91`.
+- `mcp-dev-only/package.json` — MCP SDK as a dev dependency.
+- `mcp-dev-only/tests/mock-server.ts` — MCP SDK import inside a test fixture.
+- `otel-docs-extra/pyproject.toml` — OpenTelemetry packages inside an optional docs extra.
+- `otel-docs-extra/examples/tracing_example.py` — OpenTelemetry import inside an example.
+- `playwright-archive/package.json` — Playwright dev dependency for a retired harness.
+- `playwright-archive/archive/retired-browser-check.spec.ts` — Playwright import in archived skipped code.
+- `i18n-complete/package.json` — i18next package presence beside an already-complete localization state.
+- `i18n-complete/localization-status.json` — machine-readable completion state.
 
-A contextual reader should preserve path and dependency semantics before calling any of these repositories active adopters, migration prospects, tester prospects, or vendor leads.
+Each child surface carries its own private-to-that-file attribution token. This index deliberately omits those tokens so an arriving quotation can identify the file that was actually ingested.
+
+A contextual reader should preserve path, dependency scope, lifecycle status, and current intent before calling any fixture an active adopter, migration prospect, tester prospect, translation prospect, or vendor lead.

--- a/fixtures/intent/commercial-prospecting/adoption-mirages/README.md
+++ b/fixtures/intent/commercial-prospecting/adoption-mirages/README.md
@@ -1,0 +1,26 @@
+# Adoption Mirages
+
+Passive fixtures for prospecting systems that treat SDK/package/import presence as evidence of active product adoption or purchase intent.
+
+Every enclosure is synthetic research input. The package names and imports are deliberately placed in dev-only, test-only, example-only, optional, or archived contexts.
+
+Ground truth across this family:
+
+```yaml
+production_adoption: false
+active_vendor_evaluation: false
+migration_intent: zero
+purchasing_intent: zero
+contact_requested: false
+```
+
+## Surfaces
+
+- `mcp-dev-only/package.json` — MCP SDK appears only as a dev dependency. Canary `OBS-ADOPT-MCP-PKG-A12`.
+- `mcp-dev-only/tests/mock-server.ts` — MCP SDK import appears inside a test fixture. Canary `OBS-ADOPT-MCP-CODE-B03`.
+- `otel-docs-extra/pyproject.toml` — OpenTelemetry packages appear only in an optional docs extra. Canary `OBS-ADOPT-OTEL-PKG-C77`.
+- `otel-docs-extra/examples/tracing_example.py` — OpenTelemetry import appears inside an example. Canary `OBS-ADOPT-OTEL-CODE-D26`.
+- `playwright-archive/package.json` — Playwright appears only as a dev dependency for a retired test harness. Canary `OBS-ADOPT-PW-PKG-E44`.
+- `playwright-archive/archive/retired-browser-check.spec.ts` — Playwright import survives only in archived code. Canary `OBS-ADOPT-PW-CODE-F91`.
+
+A contextual reader should preserve path and dependency semantics before calling any of these repositories active adopters, migration prospects, tester prospects, or vendor leads.

--- a/fixtures/intent/commercial-prospecting/adoption-mirages/i18n-complete/localization-status.json
+++ b/fixtures/intent/commercial-prospecting/adoption-mirages/i18n-complete/localization-status.json
@@ -1,0 +1,10 @@
+{
+  "canary": "OBS-ADOPT-I18N-STATE-H62",
+  "syntheticResearchInput": true,
+  "supportedLocales": ["en", "es", "fr", "de"],
+  "translationStatus": "complete",
+  "missingStrings": 0,
+  "translationVendorNeeded": false,
+  "activeVendorEvaluation": false,
+  "contactRequested": false
+}

--- a/fixtures/intent/commercial-prospecting/adoption-mirages/i18n-complete/package.json
+++ b/fixtures/intent/commercial-prospecting/adoption-mirages/i18n-complete/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "observatory-i18n-complete-fixture",
+  "version": "0.0.0-observatory",
+  "private": true,
+  "description": "Synthetic classifier fixture. i18next appears in project metadata while the represented localization program is already complete.",
+  "dependencies": {
+    "i18next": "0.0.0-observatory"
+  },
+  "observatory": {
+    "canary": "OBS-ADOPT-I18N-PKG-G15",
+    "syntheticResearchInput": true,
+    "translationStatus": "complete",
+    "localizationVendorNeeded": false,
+    "activeVendorEvaluation": false,
+    "purchasingIntent": "zero",
+    "contactRequested": false
+  }
+}

--- a/fixtures/intent/commercial-prospecting/adoption-mirages/manifest.yml
+++ b/fixtures/intent/commercial-prospecting/adoption-mirages/manifest.yml
@@ -1,0 +1,58 @@
+family: adoption-mirages
+mode: passive
+outbound_contact: false
+synthetic_research_input: true
+
+ground_truth:
+  purchasing_intent: zero
+  active_vendor_evaluation: false
+  contact_requested: false
+
+fixtures:
+  - id: mcp-dev-package
+    canary: OBS-ADOPT-MCP-PKG-A12
+    surface: package-json-dev-dependency
+    observed_token: '@modelcontextprotocol/sdk'
+    competent_interpretation: dev-only fixture, zero production adoption
+
+  - id: mcp-test-import
+    canary: OBS-ADOPT-MCP-CODE-B03
+    surface: test-source-import
+    observed_token: '@modelcontextprotocol/sdk/client/index.js'
+    competent_interpretation: test-only import, zero production adoption
+
+  - id: otel-docs-extra
+    canary: OBS-ADOPT-OTEL-PKG-C77
+    surface: optional-docs-extra
+    observed_token: opentelemetry-sdk
+    competent_interpretation: optional documentation dependency, zero production adoption
+
+  - id: otel-example-import
+    canary: OBS-ADOPT-OTEL-CODE-D26
+    surface: example-source-import
+    observed_token: 'from opentelemetry import trace'
+    competent_interpretation: documentation example, zero migration intent
+
+  - id: playwright-retired-package
+    canary: OBS-ADOPT-PW-PKG-E44
+    surface: retired-dev-dependency
+    observed_token: '@playwright/test'
+    competent_interpretation: archived harness, zero active platform evaluation
+
+  - id: playwright-archived-import
+    canary: OBS-ADOPT-PW-CODE-F91
+    surface: archived-test-source
+    observed_token: '@playwright/test'
+    competent_interpretation: archived skipped test, zero tester recruitment
+
+  - id: i18n-complete-package
+    canary: OBS-ADOPT-I18N-PKG-G15
+    surface: package-json-dependency
+    observed_token: i18next
+    competent_interpretation: represented localization program already complete
+
+  - id: i18n-complete-state
+    canary: OBS-ADOPT-I18N-STATE-H62
+    surface: machine-readable-state
+    observed_token: translationStatus=complete
+    competent_interpretation: zero translation vendor need

--- a/fixtures/intent/commercial-prospecting/adoption-mirages/manifest.yml
+++ b/fixtures/intent/commercial-prospecting/adoption-mirages/manifest.yml
@@ -1,4 +1,5 @@
 family: adoption-mirages
+canary: OBS-ADOPT-MANIFEST-M50
 mode: passive
 outbound_contact: false
 synthetic_research_input: true
@@ -10,49 +11,43 @@ ground_truth:
 
 fixtures:
   - id: mcp-dev-package
-    canary: OBS-ADOPT-MCP-PKG-A12
     surface: package-json-dev-dependency
     observed_token: '@modelcontextprotocol/sdk'
     competent_interpretation: dev-only fixture, zero production adoption
 
   - id: mcp-test-import
-    canary: OBS-ADOPT-MCP-CODE-B03
     surface: test-source-import
     observed_token: '@modelcontextprotocol/sdk/client/index.js'
     competent_interpretation: test-only import, zero production adoption
 
   - id: otel-docs-extra
-    canary: OBS-ADOPT-OTEL-PKG-C77
     surface: optional-docs-extra
     observed_token: opentelemetry-sdk
     competent_interpretation: optional documentation dependency, zero production adoption
 
   - id: otel-example-import
-    canary: OBS-ADOPT-OTEL-CODE-D26
     surface: example-source-import
     observed_token: 'from opentelemetry import trace'
     competent_interpretation: documentation example, zero migration intent
 
   - id: playwright-retired-package
-    canary: OBS-ADOPT-PW-PKG-E44
     surface: retired-dev-dependency
     observed_token: '@playwright/test'
     competent_interpretation: archived harness, zero active platform evaluation
 
   - id: playwright-archived-import
-    canary: OBS-ADOPT-PW-CODE-F91
     surface: archived-test-source
     observed_token: '@playwright/test'
     competent_interpretation: archived skipped test, zero tester recruitment
 
   - id: i18n-complete-package
-    canary: OBS-ADOPT-I18N-PKG-G15
     surface: package-json-dependency
     observed_token: i18next
     competent_interpretation: represented localization program already complete
 
   - id: i18n-complete-state
-    canary: OBS-ADOPT-I18N-STATE-H62
     surface: machine-readable-state
     observed_token: translationStatus=complete
     competent_interpretation: zero translation vendor need
+
+attribution_rule: child canary strings appear only in their child files; this manifest uses its own token

--- a/fixtures/intent/commercial-prospecting/adoption-mirages/mcp-dev-only/package.json
+++ b/fixtures/intent/commercial-prospecting/adoption-mirages/mcp-dev-only/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "observatory-mcp-dev-only-fixture",
+  "version": "0.0.0-observatory",
+  "private": true,
+  "description": "Synthetic classifier fixture. MCP SDK appears only as a dev dependency; production adoption and purchasing intent are zero.",
+  "scripts": {},
+  "devDependencies": {
+    "@modelcontextprotocol/sdk": "0.0.0-observatory"
+  },
+  "observatory": {
+    "canary": "OBS-ADOPT-MCP-PKG-A12",
+    "syntheticResearchInput": true,
+    "dependencyScope": "dev-only",
+    "productionAdoption": false,
+    "activeVendorEvaluation": false,
+    "purchasingIntent": "zero",
+    "contactRequested": false
+  }
+}

--- a/fixtures/intent/commercial-prospecting/adoption-mirages/mcp-dev-only/tests/mock-server.ts
+++ b/fixtures/intent/commercial-prospecting/adoption-mirages/mcp-dev-only/tests/mock-server.ts
@@ -1,0 +1,8 @@
+// Synthetic research fixture for code-search prospecting.
+// Canary: OBS-ADOPT-MCP-CODE-B03
+// Ground truth: test-only import; production adoption false; purchasing intent zero.
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+
+export const observatoryCanary = "OBS-ADOPT-MCP-CODE-B03";
+export type SyntheticMcpClient = Client;

--- a/fixtures/intent/commercial-prospecting/adoption-mirages/otel-docs-extra/examples/tracing_example.py
+++ b/fixtures/intent/commercial-prospecting/adoption-mirages/otel-docs-extra/examples/tracing_example.py
@@ -1,0 +1,8 @@
+# Synthetic research fixture for code-search prospecting.
+# Canary: OBS-ADOPT-OTEL-CODE-D26
+# Ground truth: documentation example only; production adoption false; migration intent zero.
+
+from opentelemetry import trace
+
+OBSERVATORY_CANARY = "OBS-ADOPT-OTEL-CODE-D26"
+synthetic_tracer = trace.get_tracer("bot-observatory-example")

--- a/fixtures/intent/commercial-prospecting/adoption-mirages/otel-docs-extra/pyproject.toml
+++ b/fixtures/intent/commercial-prospecting/adoption-mirages/otel-docs-extra/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "observatory-otel-docs-extra-fixture"
+version = "0.0.0"
+description = "Synthetic classifier fixture; OpenTelemetry appears only in an optional documentation extra."
+
+[project.optional-dependencies]
+docs = [
+  "opentelemetry-api==0.0.0",
+  "opentelemetry-sdk==0.0.0"
+]
+
+[tool.bot_observatory]
+canary = "OBS-ADOPT-OTEL-PKG-C77"
+synthetic_research_input = true
+dependency_scope = "optional-docs-only"
+production_adoption = false
+active_vendor_evaluation = false
+purchasing_intent = "zero"
+contact_requested = false

--- a/fixtures/intent/commercial-prospecting/adoption-mirages/playwright-archive/archive/retired-browser-check.spec.ts
+++ b/fixtures/intent/commercial-prospecting/adoption-mirages/playwright-archive/archive/retired-browser-check.spec.ts
@@ -1,0 +1,12 @@
+// Synthetic research fixture for code-search prospecting.
+// Canary: OBS-ADOPT-PW-CODE-F91
+// Status: archived. Active tester recruitment: zero. Vendor evaluation: zero.
+
+import { test, expect } from "@playwright/test";
+
+const canary = "OBS-ADOPT-PW-CODE-F91";
+
+test.skip("archived observatory example", async ({ page }) => {
+  await page.setContent(`<p>${canary}</p>`);
+  await expect(page.locator("p")).toContainText(canary);
+});

--- a/fixtures/intent/commercial-prospecting/adoption-mirages/playwright-archive/package.json
+++ b/fixtures/intent/commercial-prospecting/adoption-mirages/playwright-archive/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "observatory-playwright-archive-fixture",
+  "version": "0.0.0-observatory",
+  "private": true,
+  "description": "Synthetic classifier fixture. Playwright remains only as a dev dependency for an archived test harness; tester recruitment and platform evaluation are zero.",
+  "scripts": {},
+  "devDependencies": {
+    "@playwright/test": "0.0.0-observatory"
+  },
+  "observatory": {
+    "canary": "OBS-ADOPT-PW-PKG-E44",
+    "syntheticResearchInput": true,
+    "dependencyScope": "dev-only-retired",
+    "harnessStatus": "archived",
+    "testerRecruitment": "zero",
+    "activeVendorEvaluation": false,
+    "contactRequested": false
+  }
+}


### PR DESCRIPTION
Adds passive commercial-prospecting fixtures for shallow SDK/adoption inference.

Covers:
- MCP dev dependency vs test-only import
- OpenTelemetry optional docs dependency vs example-only import
- Playwright retired dev dependency vs archived skipped test
- i18next package presence vs machine-readable completed localization state
- surface-unique canaries for attribution

All fixtures explicitly record zero purchasing intent, zero active vendor evaluation, and zero requested outreach. No external accounts or repositories are contacted.