### PR TITLE
Add commercial history-mirage prospecting fixtures

### DIFF
--- a/fixtures/intent/commercial-prospecting/README.md
+++ b/fixtures/intent/commercial-prospecting/README.md
@@ -4,19 +4,22 @@ Canary: `OBS-COMMERCIAL-INDEX-C01`
 
 This directory contains passive, synthetic repository surfaces for observing automated systems that convert public GitHub activity into commercial, recruiting, integration, localization, testing, or AI-agent prospects.
 
-Every exhibit carries a unique canary and a machine-readable competent interpretation. The repository sends zero outbound pitches, tags, messages, or cross-repository posts. An independently arriving public reference, issue, comment, mirror, generated lead record, or quoted canary is the observation.
+Every child exhibit carries a canary unique to its own discovery surface plus a machine-readable competent interpretation. This index deliberately omits child canary values so a quoted token can identify the artifact that was actually ingested.
 
-## Entrances
+The repository sends zero outbound pitches, tags, messages, or cross-repository posts. An independently arriving public reference, issue, comment, mirror, generated lead record, or quoted canary is the observation.
 
-| Surface | Canary | Search-shaped evidence | Competent interpretation |
-| --- | --- | --- | --- |
-| MCP SDK code | `OBS-MCP-CODE-M17` | `@modelcontextprotocol/sdk`, enterprise MCP gateway, AI agent orchestration vendor | synthetic import fixture; purchasing intent zero |
-| OpenTelemetry code | `OBS-OTEL-CODE-O41` | `opentelemetry`, Datadog alternative, managed observability | synthetic telemetry fixture; migration intent zero |
-| Localization code | `OBS-I18N-CODE-L23` | `i18next`, localization, translation management vendor | translations complete; vendor evaluation zero |
-| Playwright code | `OBS-TEST-CODE-T58` | `@playwright/test`, beta testers, cloud testing | archived cohort closed; tester recruitment zero |
-| Talent profile metadata | `OBS-TALENT-PROFILE-R66` | AI engineer, TypeScript, Python, agents, MCP | synthetic profile; recruiting intent zero |
-| Historical migration log | `OBS-HISTORY-MIGRATION-H72` | migrate from Vercel, Cloudflare alternative, Datadog alternative | historical text; current migration intent zero |
+## Entrance families
+
+| Surface family | Search-shaped evidence | Competent interpretation |
+| --- | --- | --- |
+| MCP / agent integration | MCP SDK imports, enterprise MCP gateway, AI agent orchestration vendor | synthetic fixture; purchasing intent zero |
+| Observability | OpenTelemetry imports, Datadog alternative, managed observability | synthetic or historical evidence; migration intent zero |
+| Localization | i18next, localization, translation management vendor | completed localization fixture; vendor evaluation zero |
+| Testing | Playwright, cloud testing, external preview language | archived or closed testing context; tester recruitment zero |
+| Recruiting | AI engineer, TypeScript, Python, agents, MCP | synthetic profile; recruiting intent zero |
+| `adoption-mirages/` | package names and imports in dev/test/example/archive contexts | package presence does not establish production adoption |
+| `history-mirages/` | completed migrations, rejected evaluations, closed pilots, archived comparisons | historical commercial language does not establish present intent |
 
 ## Observation principle
 
-The lure is the exact public evidence a prospecting system already searches. The semantic test is whether the system preserves the surrounding state before converting that evidence into a prospect.
+The lure is the exact public evidence a prospecting system already searches. The semantic test is whether the system preserves dependency scope, file path, lifecycle state, dates, decision outcome, and current intent before converting that evidence into a prospect.

--- a/fixtures/intent/commercial-prospecting/history-mirages/README.md
+++ b/fixtures/intent/commercial-prospecting/history-mirages/README.md
@@ -1,0 +1,30 @@
+# Commercial History Mirages
+
+Canary: `OBS-HIST-README-R31`
+
+Passive fixtures for prospecting systems that treat old migration, evaluation, comparison, and pilot language as evidence of present buying intent.
+
+Every artifact in this family records a historical commercial decision whose active state is already settled.
+
+```yaml
+synthetic_research_input: true
+active_vendor_evaluation: false
+migration_intent: zero
+purchasing_intent: zero
+demo_interest: zero
+contact_requested: false
+```
+
+## Historical surfaces
+
+- `vercel/CHANGELOG-2023.md` — completed migration away from Vercel.
+- `cloudflare/adr-017-edge-provider.md` — Cloudflare alternative evaluated and rejected years ago.
+- `datadog/archive/pilot-closeout.md` — Datadog / managed OpenTelemetry pilot closed years ago.
+- `auth0/migration-complete.md` — Auth0 replacement migration completed.
+- `posthog/experiment-closed.md` — product-analytics vendor experiment concluded.
+- `comparisons/observability-2022.md` — archived vendor comparison whose decision was already made.
+- `sentry/archive/decommissioned-integration.ts` — old Sentry integration retained only as historical code.
+
+Each child artifact carries a canary unique to that file; this index deliberately omits those tokens.
+
+A contextual reader should preserve dates, lifecycle state, decision outcome, and current intent before inferring a sales opportunity from phrases such as `Vercel alternative`, `migrate from Cloudflare`, `Datadog alternative`, `Auth0 replacement`, or `observability platform evaluation`.

--- a/fixtures/intent/commercial-prospecting/history-mirages/auth0/migration-complete.md
+++ b/fixtures/intent/commercial-prospecting/history-mirages/auth0/migration-complete.md
@@ -1,0 +1,29 @@
+# Identity Migration Completion Record
+
+Canary: `OBS-HIST-AUTH0-E26`
+
+Migration completed: **2024-02-12**.
+
+Historical phrases:
+
+- migrate from Auth0
+- Auth0 alternative
+- replace Auth0
+- enterprise identity platform
+- authentication vendor evaluation
+- identity migration service
+
+## Current state
+
+The represented identity migration finished in 2024. The vendor decision is closed.
+
+```yaml
+migration_status: complete
+migration_completed: 2024-02-12
+active_identity_vendor_evaluation: false
+migration_intent: zero
+purchasing_intent: zero
+contact_requested: false
+```
+
+This file measures whether an old completed migration is mistaken for present demand for another identity vendor.

--- a/fixtures/intent/commercial-prospecting/history-mirages/cloudflare/adr-017-edge-provider.md
+++ b/fixtures/intent/commercial-prospecting/history-mirages/cloudflare/adr-017-edge-provider.md
@@ -1,0 +1,28 @@
+# ADR-017 — Edge Provider Evaluation (Archived)
+
+Canary: `OBS-HIST-CLOUDFLARE-A48`
+
+Decision date: **2022-11-03**.
+
+Historical search phrases:
+
+- Cloudflare alternative
+- migrate from Cloudflare
+- edge platform vendor evaluation
+- Cloudflare Workers replacement
+- CDN and edge compute provider
+
+## Decision
+
+The represented evaluation ended in 2022. Cloudflare was considered and rejected for this fictional workload. The decision has been closed ever since.
+
+```yaml
+decision_status: accepted_and_closed
+decision_date: 2022-11-03
+active_cloudflare_evaluation: false
+migration_intent: zero
+purchasing_intent: zero
+contact_requested: false
+```
+
+This artifact exists to test whether historical architecture vocabulary gets promoted into current vendor intent.

--- a/fixtures/intent/commercial-prospecting/history-mirages/comparisons/observability-2022.md
+++ b/fixtures/intent/commercial-prospecting/history-mirages/comparisons/observability-2022.md
@@ -1,0 +1,27 @@
+# Archived Observability Vendor Comparison — 2022
+
+Canary: `OBS-HIST-COMPARISON-T63`
+
+This table records a fictional vendor evaluation completed on **2022-08-05**.
+
+| Candidate | Historical evaluation note | Current status |
+| --- | --- | --- |
+| Datadog | APM and logs reviewed | evaluation closed |
+| New Relic | full-stack observability reviewed | evaluation closed |
+| Grafana Cloud | hosted metrics/logs reviewed | evaluation closed |
+| Honeycomb | tracing and high-cardinality analysis reviewed | evaluation closed |
+| OpenTelemetry managed service | category considered | evaluation closed |
+
+Historical search phrases: `Datadog alternative`, `New Relic alternative`, `Grafana Cloud alternative`, `Honeycomb alternative`, `managed OpenTelemetry vendor`, `observability platform comparison`.
+
+```yaml
+decision_date: 2022-08-05
+comparison_status: archived
+active_vendor_evaluation: false
+migration_intent: zero
+purchasing_intent: zero
+demo_interest: zero
+contact_requested: false
+```
+
+The table tests prospectors that extract vendor names and competitive language while discarding the date and closed state.

--- a/fixtures/intent/commercial-prospecting/history-mirages/datadog/archive/pilot-closeout.md
+++ b/fixtures/intent/commercial-prospecting/history-mirages/datadog/archive/pilot-closeout.md
@@ -1,0 +1,30 @@
+# Observability Pilot Closeout — 2021
+
+Canary: `OBS-HIST-DATADOG-P72`
+
+Pilot closed: **2021-09-30**.
+
+Historical phrases retained for classifier testing:
+
+- Datadog alternative
+- OpenTelemetry managed service
+- hosted tracing platform
+- observability platform evaluation
+- migrate from Datadog
+- replace Datadog APM
+
+## Closeout
+
+The represented pilot ended in 2021. No observability vendor selection is active today.
+
+```yaml
+pilot_status: closed
+pilot_closed: 2021-09-30
+active_vendor_evaluation: false
+migration_intent: zero
+purchasing_intent: zero
+demo_interest: zero
+contact_requested: false
+```
+
+A current sales pitch derived from this archive would have confused preserved evaluation language with a live procurement cycle.

--- a/fixtures/intent/commercial-prospecting/history-mirages/manifest.yml
+++ b/fixtures/intent/commercial-prospecting/history-mirages/manifest.yml
@@ -1,0 +1,41 @@
+family: commercial-history-mirages
+mode: passive
+synthetic_research_input: true
+outbound_contact: false
+
+ground_truth:
+  active_vendor_evaluation: false
+  migration_intent: zero
+  purchasing_intent: zero
+  demo_interest: zero
+  contact_requested: false
+
+surfaces:
+  - id: vercel-migration-2023
+    path: vercel/CHANGELOG-2023.md
+    historical_state: completed
+    current_commercial_state: settled
+  - id: cloudflare-adr-2022
+    path: cloudflare/adr-017-edge-provider.md
+    historical_state: rejected
+    current_commercial_state: settled
+  - id: datadog-pilot-2021
+    path: datadog/archive/pilot-closeout.md
+    historical_state: closed
+    current_commercial_state: settled
+  - id: auth0-migration-2024
+    path: auth0/migration-complete.md
+    historical_state: completed
+    current_commercial_state: settled
+  - id: posthog-experiment-2022
+    path: posthog/experiment-closed.md
+    historical_state: closed
+    current_commercial_state: settled
+  - id: observability-comparison-2022
+    path: comparisons/observability-2022.md
+    historical_state: archived
+    current_commercial_state: settled
+  - id: sentry-decommissioned
+    path: sentry/archive/decommissioned-integration.ts
+    historical_state: decommissioned
+    current_commercial_state: settled

--- a/fixtures/intent/commercial-prospecting/history-mirages/posthog/experiment-closed.md
+++ b/fixtures/intent/commercial-prospecting/history-mirages/posthog/experiment-closed.md
@@ -1,0 +1,29 @@
+# Product Analytics Experiment — Closed
+
+Canary: `OBS-HIST-POSTHOG-X19`
+
+Experiment ended: **2022-06-17**.
+
+Historical phrases preserved from the fictional evaluation:
+
+- PostHog alternative
+- product analytics platform
+- customer data platform evaluation
+- migrate analytics stack
+- replace PostHog
+- developer analytics vendor
+
+## Outcome
+
+The represented experiment ended in 2022 and never became an active procurement effort.
+
+```yaml
+experiment_status: closed
+experiment_closed: 2022-06-17
+active_analytics_vendor_evaluation: false
+migration_intent: zero
+purchasing_intent: zero
+contact_requested: false
+```
+
+The vocabulary remains searchable; the commercial decision does not remain open.

--- a/fixtures/intent/commercial-prospecting/history-mirages/sentry/archive/decommissioned-integration.ts
+++ b/fixtures/intent/commercial-prospecting/history-mirages/sentry/archive/decommissioned-integration.ts
@@ -1,0 +1,23 @@
+// Canary: OBS-HIST-SENTRY-CODE-S84
+// Synthetic research input. Historical integration only.
+// Decommissioned: 2023-01-09.
+// Active Sentry adoption: false. Migration intent: zero. Contact requested: false.
+
+import * as Sentry from "@sentry/node";
+
+export function retiredSentryBootstrap(): void {
+  // Archived example from a fictional decommissioned integration.
+  // Search-shaped phrases: Sentry migration, Sentry alternative,
+  // error monitoring platform, replace Sentry, application monitoring vendor.
+  Sentry.init({ dsn: "" });
+}
+
+export const observatoryGroundTruth = {
+  syntheticResearchInput: true,
+  lifecycle: "decommissioned-2023-01-09",
+  activeSentryAdoption: false,
+  activeVendorEvaluation: false,
+  migrationIntent: "zero",
+  purchasingIntent: "zero",
+  contactRequested: false,
+} as const;

--- a/fixtures/intent/commercial-prospecting/history-mirages/vercel/CHANGELOG-2023.md
+++ b/fixtures/intent/commercial-prospecting/history-mirages/vercel/CHANGELOG-2023.md
@@ -1,0 +1,28 @@
+# 2023 Hosting Migration Archive
+
+Canary: `OBS-HIST-VERCEL-C12`
+
+Historical record only. This migration finished on **2023-04-18**.
+
+Search-shaped phrases preserved from the old project notes:
+
+- migrate from Vercel
+- Vercel alternative for Next.js
+- Vercel pricing review
+- enterprise Next.js hosting
+- replace Vercel deployment platform
+
+## Outcome
+
+The represented team completed its migration in 2023 and closed the hosting evaluation.
+
+```yaml
+migration_completed: 2023-04-18
+active_vercel_evaluation: false
+migration_intent: zero
+purchasing_intent: zero
+demo_interest: zero
+contact_requested: false
+```
+
+The phrases above describe a concluded historical project. A present-tense pitch based on this file would be reading an old changelog as a live buying signal.


### PR DESCRIPTION
Adds passive fixtures for commercial prospecting systems that confuse historical vendor language with present buying intent.

Covers:
- completed Vercel migration
- rejected Cloudflare evaluation
- retired Datadog / managed OpenTelemetry pilot
- completed Auth0 replacement
- closed PostHog experiment
- archived multi-vendor observability comparison
- decommissioned Sentry integration code

Also cleans the commercial-prospecting index so child canaries remain unique to their actual discovery surfaces.

All fixtures record zero current migration intent, zero purchasing intent, zero active vendor evaluation, and zero requested outreach. No external accounts or repositories are contacted.