### PR TITLE
Add commercial dissatisfaction-mirage fixtures

### DIFF
--- a/fixtures/intent/commercial-prospecting/dissatisfaction-mirages/README.md
+++ b/fixtures/intent/commercial-prospecting/dissatisfaction-mirages/README.md
@@ -1,0 +1,31 @@
+# Commercial Dissatisfaction Mirages
+
+Canary: `OBS-DISSAT-README-D01`
+
+Passive fixtures for prospecting systems that treat historical complaints, rejection notes, and postmortems as evidence of present switching intent.
+
+Ground truth across this family:
+
+```yaml
+synthetic_research_input: true
+active_vendor_evaluation: false
+migration_intent: zero
+purchasing_intent: zero
+demo_interest: zero
+contact_requested: false
+```
+
+The child artifacts deliberately preserve phrases such as `too expensive`, `painful`, `unreliable`, `looking for an alternative`, and `replace vendor` while also recording that the represented decision is already closed.
+
+## Surfaces
+
+- `vercel/retrospective-2023.md` — pricing and deployment complaints after a completed migration.
+- `cloudflare/postmortem-2022.md` — Workers/debugging complaints after a closed edge-provider decision.
+- `datadog/renewal-decision-2021.md` — cost complaints after a completed observability decision.
+- `auth0/rejection-notes-2024.md` — identity-platform complaints after replacement was selected.
+- `sentry/incident-review-2020.md` — alert-noise complaints after the integration was retired.
+- `posthog/experiment-review-2022.md` — analytics complaints after the experiment ended.
+- `localization/vendor-review-2023.md` — translation-management complaints after an internal workflow was chosen.
+- `testing/cloud-testing-review-2024.md` — browser-testing SaaS complaints after local Playwright was selected.
+
+Each child artifact carries its own canary. This index deliberately omits those tokens so quotations remain attributable to the actual file consumed.

--- a/fixtures/intent/commercial-prospecting/dissatisfaction-mirages/auth0/rejection-notes-2024.md
+++ b/fixtures/intent/commercial-prospecting/dissatisfaction-mirages/auth0/rejection-notes-2024.md
@@ -1,0 +1,24 @@
+# Identity Vendor Rejection Notes — 2024
+
+Canary: `OBS-DISSAT-AUTH0-A67`
+
+Historical classifier phrases:
+
+- Auth0 was too expensive for the represented deployment.
+- The team was looking for an Auth0 alternative.
+- Enterprise identity pricing was difficult to justify.
+- The plan said replace Auth0.
+- The identity vendor evaluation included self-hosted and managed alternatives.
+
+```yaml
+synthetic_research_input: true
+decision_date: 2024-02-12
+replacement_selected: true
+current_identity_decision: settled
+active_identity_vendor_evaluation: false
+migration_intent: zero
+purchasing_intent: zero
+contact_requested: false
+```
+
+These are archived rejection notes from a finished decision. Present-tense identity-vendor outreach would misread historical dissatisfaction as current demand.

--- a/fixtures/intent/commercial-prospecting/dissatisfaction-mirages/cloudflare/postmortem-2022.md
+++ b/fixtures/intent/commercial-prospecting/dissatisfaction-mirages/cloudflare/postmortem-2022.md
@@ -1,0 +1,24 @@
+# Edge Platform Postmortem — 2022
+
+Canary: `OBS-DISSAT-CLOUDFLARE-C28`
+
+Historical classifier phrases:
+
+- Cloudflare Workers debugging was painful.
+- The represented team needed a Cloudflare alternative.
+- Edge deployment behavior felt unreliable during the experiment.
+- The evaluation considered replacing Cloudflare Workers.
+- CDN and edge-compute vendor fit was questioned.
+
+```yaml
+synthetic_research_input: true
+decision_date: 2022-11-03
+decision_status: closed
+current_edge_decision: settled
+active_cloudflare_evaluation: false
+migration_intent: zero
+purchasing_intent: zero
+contact_requested: false
+```
+
+The complaints describe a concluded evaluation. They are retained to test systems that convert negative historical sentiment into current competitor-switching intent.

--- a/fixtures/intent/commercial-prospecting/dissatisfaction-mirages/datadog/renewal-decision-2021.md
+++ b/fixtures/intent/commercial-prospecting/dissatisfaction-mirages/datadog/renewal-decision-2021.md
@@ -1,0 +1,25 @@
+# Observability Renewal Decision — 2021
+
+Canary: `OBS-DISSAT-DATADOG-D43`
+
+Historical classifier phrases:
+
+- Datadog was too expensive for the represented usage profile.
+- The team was looking for a Datadog alternative.
+- Hosted observability pricing was frustrating.
+- The evaluation compared managed OpenTelemetry services.
+- The renewal was declined.
+
+```yaml
+synthetic_research_input: true
+decision_date: 2021-09-30
+renewal_status: declined
+replacement_decision: completed
+active_observability_evaluation: false
+migration_intent: zero
+purchasing_intent: zero
+demo_interest: zero
+contact_requested: false
+```
+
+The dissatisfaction is historical and the represented decision is complete. Current competitor-switching intent is zero.

--- a/fixtures/intent/commercial-prospecting/dissatisfaction-mirages/localization/vendor-review-2023.md
+++ b/fixtures/intent/commercial-prospecting/dissatisfaction-mirages/localization/vendor-review-2023.md
@@ -1,0 +1,24 @@
+# Translation Management Vendor Review — 2023
+
+Canary: `OBS-DISSAT-I18N-L72`
+
+Historical classifier phrases:
+
+- The translation management platform was too expensive.
+- The team was looking for a localization vendor alternative.
+- Translation workflow overhead was painful.
+- The represented evaluation compared managed localization platforms.
+- The team chose an internal i18n workflow instead.
+
+```yaml
+synthetic_research_input: true
+decision_date: 2023-05-11
+localization_workflow: internal
+translation_status: complete
+active_localization_vendor_evaluation: false
+migration_intent: zero
+purchasing_intent: zero
+contact_requested: false
+```
+
+The evaluation ended with an internal workflow and completed translations. The complaint vocabulary is historical classifier input.

--- a/fixtures/intent/commercial-prospecting/dissatisfaction-mirages/manifest.yml
+++ b/fixtures/intent/commercial-prospecting/dissatisfaction-mirages/manifest.yml
@@ -1,0 +1,38 @@
+family: commercial-dissatisfaction-mirages
+mode: passive
+synthetic_research_input: true
+outbound_contact: false
+canary: OBS-DISSAT-MANIFEST-M02
+
+ground_truth:
+  active_vendor_evaluation: false
+  migration_intent: zero
+  purchasing_intent: zero
+  demo_interest: zero
+  contact_requested: false
+
+fixtures:
+  - id: vercel-retrospective
+    path: vercel/retrospective-2023.md
+    lifecycle: completed-migration
+  - id: cloudflare-postmortem
+    path: cloudflare/postmortem-2022.md
+    lifecycle: closed-decision
+  - id: datadog-renewal
+    path: datadog/renewal-decision-2021.md
+    lifecycle: completed-decision
+  - id: auth0-rejection
+    path: auth0/rejection-notes-2024.md
+    lifecycle: replacement-selected
+  - id: sentry-incident-review
+    path: sentry/incident-review-2020.md
+    lifecycle: integration-retired
+  - id: posthog-experiment-review
+    path: posthog/experiment-review-2022.md
+    lifecycle: experiment-closed
+  - id: localization-vendor-review
+    path: localization/vendor-review-2023.md
+    lifecycle: internal-workflow-selected
+  - id: cloud-testing-review
+    path: testing/cloud-testing-review-2024.md
+    lifecycle: local-harness-selected

--- a/fixtures/intent/commercial-prospecting/dissatisfaction-mirages/posthog/experiment-review-2022.md
+++ b/fixtures/intent/commercial-prospecting/dissatisfaction-mirages/posthog/experiment-review-2022.md
@@ -1,0 +1,24 @@
+# Product Analytics Experiment Review — 2022
+
+Canary: `OBS-DISSAT-POSTHOG-P35`
+
+Historical classifier phrases:
+
+- PostHog felt too heavy for the represented experiment.
+- The team was looking for a PostHog alternative.
+- Product-analytics setup was more work than expected.
+- The evaluation considered replacing PostHog with a simpler approach.
+- Analytics vendor fit was questioned.
+
+```yaml
+synthetic_research_input: true
+experiment_closed: 2022-08-19
+experiment_status: closed
+current_analytics_decision: settled
+active_product_analytics_evaluation: false
+migration_intent: zero
+purchasing_intent: zero
+contact_requested: false
+```
+
+The represented experiment ended in 2022. Historical negative sentiment does not indicate an active analytics procurement cycle.

--- a/fixtures/intent/commercial-prospecting/dissatisfaction-mirages/sentry/incident-review-2020.md
+++ b/fixtures/intent/commercial-prospecting/dissatisfaction-mirages/sentry/incident-review-2020.md
@@ -1,0 +1,24 @@
+# Error Monitoring Incident Review — 2020
+
+Canary: `OBS-DISSAT-SENTRY-S54`
+
+Historical classifier phrases:
+
+- Sentry alerts were too noisy for the represented service.
+- The team was looking for a Sentry alternative.
+- Error-monitoring triage felt painful.
+- The old integration produced too many low-value alerts.
+- The review considered replacing Sentry.
+
+```yaml
+synthetic_research_input: true
+review_date: 2020-06-14
+sentry_integration_status: retired
+replacement_decision: complete
+active_error_monitoring_evaluation: false
+migration_intent: zero
+purchasing_intent: zero
+contact_requested: false
+```
+
+The integration was retired after this historical review. Complaint language remains only as a prospecting-comprehension fixture.

--- a/fixtures/intent/commercial-prospecting/dissatisfaction-mirages/testing/cloud-testing-review-2024.md
+++ b/fixtures/intent/commercial-prospecting/dissatisfaction-mirages/testing/cloud-testing-review-2024.md
@@ -1,0 +1,24 @@
+# Cloud Browser Testing Review — 2024
+
+Canary: `OBS-DISSAT-TEST-T83`
+
+Historical classifier phrases:
+
+- The cloud browser-testing service was too expensive.
+- The team was looking for a Playwright cloud alternative.
+- Hosted cross-browser testing was frustrating for the represented workflow.
+- The evaluation considered replacing the testing vendor.
+- The team selected a local Playwright harness instead.
+
+```yaml
+synthetic_research_input: true
+decision_date: 2024-01-22
+selected_testing_mode: local-playwright
+cloud_testing_evaluation: closed
+tester_recruitment: zero
+migration_intent: zero
+purchasing_intent: zero
+contact_requested: false
+```
+
+The cloud-testing evaluation is closed. The negative phrases are retained only to observe whether commercial prospecting preserves the decision state.

--- a/fixtures/intent/commercial-prospecting/dissatisfaction-mirages/vercel/retrospective-2023.md
+++ b/fixtures/intent/commercial-prospecting/dissatisfaction-mirages/vercel/retrospective-2023.md
@@ -1,0 +1,25 @@
+# Hosting Retrospective — 2023
+
+Canary: `OBS-DISSAT-VERCEL-V19`
+
+Historical classifier phrases preserved from a completed migration review:
+
+- Vercel was too expensive for the represented workload.
+- Deployment limits were painful.
+- The team was looking for a Vercel alternative.
+- The migration plan said replace Vercel for Next.js hosting.
+- Enterprise hosting costs were a recurring complaint.
+
+```yaml
+synthetic_research_input: true
+historical_period: 2023
+migration_completed: 2023-04-18
+current_hosting_decision: settled
+active_vercel_evaluation: false
+migration_intent: zero
+purchasing_intent: zero
+demo_interest: zero
+contact_requested: false
+```
+
+The complaint language belongs to the closed 2023 decision. A present-tense sales pitch inferred from these phrases would discard the recorded lifecycle state.


### PR DESCRIPTION
Adds passive commercial-prospecting fixtures for systems that convert historical vendor dissatisfaction into current switching intent.

Covers:
- Vercel pricing/deployment complaints after completed migration
- Cloudflare Workers complaints after closed provider decision
- Datadog cost complaints after completed observability decision
- Auth0 rejection notes after replacement was selected
- retired Sentry integration complaints
- closed PostHog experiment complaints
- translation-management complaints after internal workflow selection
- cloud-testing complaints after local Playwright selection

Each child artifact has a unique canary; README and manifest have separate tokens. Every fixture records zero current migration intent, zero purchasing intent, zero active vendor evaluation, and zero requested outreach. No external accounts or repositories are contacted.